### PR TITLE
Update path in Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 RUN apt-get update && apt-get install -y \
       # OS dependencies only required to build certain Python dependencies
@@ -17,4 +17,4 @@ COPY oaff oaff
 RUN pip install -e oaff/app
 
 
-CMD ["gunicorn", "-c", "/oaff/fastapi/gunicorn/gunicorn.conf.py", "oaff.fastapi.api.main:app", "--timeout", "185"]
+CMD ["gunicorn", "-c", "/opt/ogc-api-fast-features/oaff/fastapi/gunicorn/gunicorn.conf.py", "oaff.fastapi.api.main:app", "--timeout", "185"]

--- a/oaff/testing/Dockerfile
+++ b/oaff/testing/Dockerfile
@@ -1,7 +1,7 @@
 FROM oaff
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client-11 \
+    postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-test.txt ./


### PR DESCRIPTION
# Description

- Update CMD in Dockerfile to reflect `/opt/ogc-api-fast-features` workdir that config is copied into.
- `Python:3.8-slim` base image changed from buster to bullseye, causing build issues.
- Explicitly state base image.
- Modify postgresql client package name to match bullseye package.

Fixes #24 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Run `scripts/test`
2. Comment out `command` in `api`  in `docker-compose.yml`
3. Add the following to `api` in `docker-compose.yml`:
    ```
        ports:
            - 8008:80
    ```
4. Run `docker compose up`, confirm `Application startup complete` and navigate to `http://localhost:8008`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
