### PR TITLE
Add mypy as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,13 @@ repos:
     rev: 21.5b1
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
-# -   repo: local
-#     hooks:
-    # custom hook, rather than mypy hook, gives more control over mypy parameters
-    # - id: mypy-executor
-    #   name: MyPy Executor
-    #   entry: ./mypy.sh
-    #   language: system
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+    - id: mypy
+      language_version: python

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following provides information for developers looking to maintain or extend 
 ## Architecture
 
 ## Pre-commit hooks
-Git hooks are used to run formatting (isort, black), linting (flake8), and type-checking (mypy). You can install the pre-commit scripts with `pre-commit install`. Thereafter, the scripts defined in `.pre-commit-config.yaml` will be run on the files included in a commit. Specific tool configurations are included in `pyproject.toml`.
+Git hooks are used to run formatting (isort, black), linting (flake8), and type-checking (mypy). The pre-commit scripts can be installed by running `scripts/setup` or simply `pre-commit install`. Thereafter, the scripts defined in `.pre-commit-config.yaml` will be run on the files included in a commit. Specific tool configurations are included in `pyproject.toml`.
 
 ### FastAPI
 oaff's frontend uses FastAPI but the backend is not tightly-coupled to that framework. Frontend routers interpret path and query parameters and build request objects using request classes defined in the backend. A single `delegate` method passes request objects to the backend and awaits a response. Responses provide either data or error detail and an appropriate API response is constructed from whichever is returned. During the frontend's startup sequence a `FrontendConfiguration` object is passed to the backend, providing key frontend properties that need to be known by the backend. Examples:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ The following provides information for developers looking to maintain or extend 
 
 ## Architecture
 
+## Pre-commit hooks
+Git hooks are used to run formatting (isort, black), linting (flake8), and type-checking (mypy). You can install the pre-commit scripts with `pre-commit install`. Thereafter, the scripts defined in `.pre-commit-config.yaml` will be run on the files included in a commit. Specific tool configurations are included in `pyproject.toml`.
+
 ### FastAPI
 oaff's frontend uses FastAPI but the backend is not tightly-coupled to that framework. Frontend routers interpret path and query parameters and build request objects using request classes defined in the backend. A single `delegate` method passes request objects to the backend and awaits a response. Responses provide either data or error detail and an appropriate API response is constructed from whichever is returned. During the frontend's startup sequence a `FrontendConfiguration` object is passed to the backend, providing key frontend properties that need to be known by the backend. Examples:
 1. when the backend builds a data response to an API request it needs to know the root path from which the API is served to correctly build any links in the response

--- a/mypy.sh
+++ b/mypy.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-mypy --namespace-packages -p oaff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 90
-py38 = true
 include = '\.pyi?$'
 exclude = '''
 
@@ -33,3 +32,10 @@ known_first_party='sample_lib'
 indent=4
 sections='FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER'
 no_lines_before='LOCALFOLDER'
+
+[tool.mypy]
+exclude="^(tests|testing)$"
+namespace_packages=true
+explicit_package_bases=true
+ignore_missing_imports=true
+ignore_errors=true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ safety==1.10.3
 isort==5.8.0
 black==21.5b1
 flake8==3.9.2
-mypy==0.812
+mypy==0.910
 fastapi==0.65.2
 uvicorn==0.13.4
 pytest==6.2.4

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -5,4 +5,5 @@ set -e
 pip install flake8==3.9.2
 cd $(dirname $0)/..
 flake8 .
+mypy -p oaff
 scripts/test --no-cache


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. 

Fixes #5 

- Adds mypy as a pre-commit hook
- Adds mypy step in `scripts/cibuild`
- Configuration added to pyproject.toml which requires a more recent version of mypy (v0.812 -> v0.910). 
- Removed `py38` options from [tool.black] to support pre-commit in py39 venv
- Current config produces mypy errors, using `ignore_errors` config until they can be addressed
- 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

Explain what someone needs to do in order to test the functionality of the changes.

Run `pre-commit run --all-files` or `mypy -p oaff` 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ran pre-commit locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
