### PR TITLE
Fix OGC OpenAPI path when API_ROOT_PATH set

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ During data interrogation oaff will identify all tables that can be served via i
 Follow the instructions [here](https://cite.opengeospatial.org/teamengine/) to execute CITE compliance tests against oaff. If executing tests in a Docker container against an API instance in a separate Docker container you may need to reference a special hostname. For example, to execute using Docker on MacOS:
 * `scripts/server && scripts/demo_data` to start the API containers
 * `docker run --rm -p 8081:8080 ogccite/ets-ogcapi-features10` to start the CITE testing container
-* Navigate browser to http://localhost:8081
+* Navigate browser to http://localhost:8081/teamengine
 * Login with `ogctest/ogctest`
 * Start a new test session
 * Provide http://docker.for.mac.localhost:8008 for the test URL

--- a/oaff/fastapi/api/openapi/openapi.py
+++ b/oaff/fastapi/api/openapi/openapi.py
@@ -3,6 +3,7 @@ from typing import Callable
 from fastapi.applications import FastAPI
 from fastapi.requests import Request
 
+from oaff.fastapi.api.settings import ROOT_PATH
 from oaff.fastapi.api.openapi.vnd_response import VndResponse
 
 
@@ -13,9 +14,10 @@ def get_openapi_handler(app: FastAPI) -> Callable[[Request], VndResponse]:
         definition = app.openapi().copy()
         for path in definition["paths"].values():
             if "get" in path:
-                for parameter in path["get"]["parameters"]:
-                    if "style" not in parameter:
-                        parameter["style"] = "form"
+                if "parameters" in path["get"]:
+                    for parameter in path["get"]["parameters"]:
+                        if "style" not in parameter:
+                            parameter["style"] = "form"
 
         # This API actually expects BBOX as a string but OGC spec requires
         # array with form-style, which is not possible in FastAPI.
@@ -24,7 +26,7 @@ def get_openapi_handler(app: FastAPI) -> Callable[[Request], VndResponse]:
         collection_items_bbox_param = list(
             filter(
                 lambda parameter: parameter["name"] == "bbox",
-                definition["paths"]["/collections/{collection_id}/items"]["get"][
+                definition["paths"][f"{ROOT_PATH}/collections/{{collection_id}}/items"]["get"][
                     "parameters"
                 ],
             )


### PR DESCRIPTION
# Description

Fix OGC OpenAPI path when API_ROOT_PATH set:
- Add if statement for path parameters key.
- Add ROOT_PATH to "/collections/{collection_id}/items" key.
- Update local CITE test URL in readme.

Fixes # (#34 )

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Instructions

1. Clone the repo and start the API with `scripts/server && scripts/demo_data`.
2. Add http://localhost:8008/ to QGIS and attempt add a layer to a map or alternatively visit http://localhost:8008/ogc/openapi.json. The layer will be added to QGIS or the content of openapi.json will be visible.
3. Add `API_ROOT_PATH=/oaff` to `.env-dev`.
4. Stop the API with `scripts/stop`.
5. Start the API again with ``scripts/server && scripts/demo_data`.
6. Add http://localhost:8008/oaff to QGIS and attempt add a layer to a map or alternatively visit http://localhost:8008/oaff/ogc/openapi.json. The layer will be added to QGIS or the content of openapi.json will be visible.

# How Has This Been Tested?

- [x] Ran `scripts/test`
- [x] Went through the above steps
- [x] Ran [CITE Compliance](https://github.com/microsoft/ogc-api-fast-features#cite-compliance) tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
